### PR TITLE
Lowered minimum base version.

### DIFF
--- a/friday-juicypixels.cabal
+++ b/friday-juicypixels.cabal
@@ -26,7 +26,7 @@ library
   exposed-modules:     Vision.Image.JuicyPixels
   -- other-modules:
   other-extensions:    ViewPatterns
-  build-depends:       base            >= 4.7     &&  <  4.9
+  build-depends:       base            >= 4.6     &&  <  4.9
                      , friday          >= 0.2     &&  <  0.3
                      , JuicyPixels
                      , vector


### PR DESCRIPTION
Hi!

I needed this package with GHC 7.6.3 (I'm developing an application on a Raspberry Pi 2, and this is the version that is available that sort of works).

This library compiles fine, and works with the lower bounds on base, so it would be nice to include them for us weirdos that need to use an older GHC!

Thanks!
